### PR TITLE
add alias for Canon KISS M to M50 entry in caneras.xml

### DIFF
--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1483,6 +1483,22 @@
 			<Hint name="wb_offset" value="85"/>
 		</Hints>
 	</Camera>
+		<Camera make="Canon" model="Canon EOS R6">
+		<ID make="Canon" model="EOS R6">Canon EOS R6</ID>
+		<CFA width="2" height="2">
+			<Color x="0" y="0">RED</Color>
+			<Color x="1" y="0">GREEN</Color>
+			<Color x="0" y="1">GREEN</Color>
+			<Color x="1" y="1">BLUE</Color>
+		</CFA>
+		<Sensor black="2048" white="16384"/>
+		<Sensor black="512" white="16384" iso_list="50 100 125 160 200 250"/>
+		<Sensor black="2040" white="16384" iso_list="204800"/>
+		<Hints>
+			<Hint name="wb_offset" value="85"/>
+		</Hints>
+	</Camera>
+	</Camera>
 	<Camera make="Canon" model="Canon EOS M50">
 		<ID make="Canon" model="EOS M50">Canon EOS M50</ID>
 		<CFA width="2" height="2">

--- a/data/cameras.xml
+++ b/data/cameras.xml
@@ -1498,7 +1498,6 @@
 			<Hint name="wb_offset" value="85"/>
 		</Hints>
 	</Camera>
-	</Camera>
 	<Camera make="Canon" model="Canon EOS M50">
 		<ID make="Canon" model="EOS M50">Canon EOS M50</ID>
 		<CFA width="2" height="2">
@@ -1513,6 +1512,9 @@
 		<Sensor black="511" white="14338" iso_list="200 250"/>
 		<Sensor black="2050" white="10749" iso_list="320 640 1250 2500 5000"/>
 		<Sensor black="2048" white="14338" iso_list="16000 20000"/>
+		<Aliases>
+			<Alias id="EOS KISS M">Canon EOS KISS M</Alias>
+		</Aliases>
 		<Hints>
 			<Hint name="wb_offset" value="71"/>
 		</Hints>


### PR DESCRIPTION
Add alias for Canon EOS KISS M, which is the brandname of the Canon EOS M50 in the Japanese market segment. 